### PR TITLE
Fix unrendered statement justifications

### DIFF
--- a/aida_viz/__main__.py
+++ b/aida_viz/__main__.py
@@ -2,6 +2,7 @@ import argparse
 from pathlib import Path
 
 from rdflib import RDF, Graph, Namespace
+from tqdm import tqdm
 
 from aida_viz.corpus.core import Corpus
 from aida_viz.elements import Element
@@ -61,14 +62,13 @@ def main(
         clusters = list(graph.subjects(predicate=RDF.type, object=aida.SameAsCluster))
 
         element_ids = clusters + entities + events + relations
-        elements = {
-            element_id: Element.from_uriref(element_id, graph=graph)
-            for element_id in element_ids
-        }
+        elements = {}
+        for element_id in tqdm(element_ids):
+            elements[element_id] = Element.from_uriref(element_id, graph=graph)
 
         corpus = Corpus(db_path)
-        renderer = HtmlWriter(corpus, elements)
-        renderer.write_to_dir(out_dir, output_file_name=f"{aif_file.stem}.html")
+        renderer = HtmlWriter(corpus, elements, directory=out_dir)
+        renderer.write_to_dir(output_file_name=f"{aif_file.stem}.html")
     return out_dir
 
 

--- a/aida_viz/__main__.py
+++ b/aida_viz/__main__.py
@@ -62,9 +62,10 @@ def main(
         clusters = list(graph.subjects(predicate=RDF.type, object=aida.SameAsCluster))
 
         element_ids = clusters + entities + events + relations
-        elements = {}
-        for element_id in tqdm(element_ids):
-            elements[element_id] = Element.from_uriref(element_id, graph=graph)
+        elements = {
+            element_id: Element.from_uriref(element_id, graph=graph)
+            for element_id in tqdm(element_ids)
+        }
 
         corpus = Corpus(db_path)
         renderer = HtmlWriter(corpus, elements, directory=out_dir)

--- a/aida_viz/__main__.py
+++ b/aida_viz/__main__.py
@@ -31,7 +31,7 @@ def getargs():
         type=Path,
         help="Directory to output the visualization. Overwrites any files matching the naming scheme.",
         dest="out_dir",
-        default="./visualizer_results",
+        default="./aida-viz-html",
     )
     arg("--by_clusters", action="store_true")
     arg("--verbose", "-v", action="store_true")

--- a/aida_viz/htmlwriter/core.py
+++ b/aida_viz/htmlwriter/core.py
@@ -6,7 +6,6 @@ from immutablecollections import immutabledict
 from jinja2 import Template
 from rdflib import RDF, URIRef
 from rdflib.namespace import split_uri
-from tqdm import tqdm
 
 from aida_viz.corpus.core import Corpus
 from aida_viz.documents import get_title_sentence, render_single_justification_document
@@ -18,7 +17,12 @@ class HtmlWriter:
     corpus: Corpus
     elements: Dict[URIRef, Element]
 
-    def __init__(self, corpus: Corpus, elements: Dict[URIRef, Element], directory='./aida-viz-html'):
+    def __init__(
+        self,
+        corpus: Corpus,
+        elements: Dict[URIRef, Element],
+        directory="./aida-viz-html",
+    ):
         self.corpus = corpus
         self.elements = elements
         self.parent_child_map = {
@@ -27,11 +31,7 @@ class HtmlWriter:
         }
         self.output_dir: Path = directory
 
-    def write_to_dir(
-        self,
-        output_file_name: str = "visualization.html",
-        pbar: Optional[tqdm] = None,
-    ):
+    def write_to_dir(self, output_file_name: str = "visualization.html"):
         if self.output_dir.exists() and not self.output_dir.is_dir():
             raise ValueError("argument `output_dir` must be directory.")
 
@@ -63,19 +63,14 @@ class HtmlWriter:
         style_file = self.output_dir / "style.css"
         style_file.write_text(STYLE)
 
-
     def write_justification_context_html(self, j: Justification):
         docs_dir = self.output_dir / "docs"
         docs_dir.mkdir(parents=True, exist_ok=True)
 
-        document_id = (
-            j.parent_id if j.parent_id else self.parent_child_map[j.child_id]
-        )
+        document_id = j.parent_id if j.parent_id else self.parent_child_map[j.child_id]
         document = self.corpus[document_id]
 
-        justification_document_html = render_single_justification_document(
-            document, j
-        )
+        justification_document_html = render_single_justification_document(document, j)
 
         rendered_html = Template(TEMPLATE).render(
             document=immutabledict(
@@ -88,12 +83,9 @@ class HtmlWriter:
             )
         )
         justification_file = (
-            docs_dir
-            / f"{document['parent_id']}_{j.span_start}-{j.span_end}.html"
+            docs_dir / f"{document['parent_id']}_{j.span_start}-{j.span_end}.html"
         )
         justification_file.write_text(rendered_html)
-
-
 
     def render_element(self, element: Element) -> str:
         html_lines = ["<div>"]

--- a/aida_viz/htmlwriter/core.py
+++ b/aida_viz/htmlwriter/core.py
@@ -18,25 +18,22 @@ class HtmlWriter:
     corpus: Corpus
     elements: Dict[URIRef, Element]
 
-    def __init__(self, corpus: Corpus, elements: Dict[URIRef, Element]):
+    def __init__(self, corpus: Corpus, elements: Dict[URIRef, Element], directory='./aida-viz-html'):
         self.corpus = corpus
         self.elements = elements
         self.parent_child_map = {
             r["child_id"]: r["parent_id"]
             for r in self.corpus.query(f"SELECT parent_id, child_id FROM documents")
         }
+        self.output_dir: Path = directory
 
     def write_to_dir(
         self,
-        output_dir: Path,
         output_file_name: str = "visualization.html",
         pbar: Optional[tqdm] = None,
     ):
-        if output_dir.exists() and not output_dir.is_dir():
+        if self.output_dir.exists() and not self.output_dir.is_dir():
             raise ValueError("argument `output_dir` must be directory.")
-
-        docs_dir = output_dir / "docs"
-        docs_dir.mkdir(parents=True, exist_ok=True)
 
         for element in self.elements.values():
             all_justifications = (
@@ -46,35 +43,11 @@ class HtmlWriter:
                 j for j in all_justifications if j.span_start and j.span_end
             ]
             for j in renderable_justifications:
-                document_id = (
-                    j.parent_id if j.parent_id else self.parent_child_map[j.child_id]
-                )
-                document = self.corpus[document_id]
-
-                justification_document_html = render_single_justification_document(
-                    document, j
-                )
-
-                rendered_html = Template(TEMPLATE).render(
-                    document=immutabledict(
-                        {
-                            "id": document["parent_id"],
-                            "title": get_title_sentence(document["fulltext"]),
-                            "html": justification_document_html,
-                            "span": f"{j.span_start}:{j.span_end}",
-                        }
-                    )
-                )
-                justification_file = (
-                    docs_dir
-                    / f"{document['parent_id']}_{j.span_start}-{j.span_end}.html"
-                )
-                justification_file.write_text(rendered_html)
-
+                self.write_justification_context_html(j)
                 if pbar:
                     pbar.update()
 
-        html_file = output_dir / output_file_name
+        html_file = self.output_dir / output_file_name
 
         html_lines = [
             "<html>",
@@ -99,8 +72,40 @@ class HtmlWriter:
         rendered_html = "\n".join(html_lines)
         html_file.write_text(rendered_html)
 
-        style_file = output_dir / "style.css"
+        style_file = self.output_dir / "style.css"
         style_file.write_text(STYLE)
+
+
+    def write_justification_context_html(self, j: Justification):
+        docs_dir = self.output_dir / "docs"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+
+        document_id = (
+            j.parent_id if j.parent_id else self.parent_child_map[j.child_id]
+        )
+        document = self.corpus[document_id]
+
+        justification_document_html = render_single_justification_document(
+            document, j
+        )
+
+        rendered_html = Template(TEMPLATE).render(
+            document=immutabledict(
+                {
+                    "id": document["parent_id"],
+                    "title": get_title_sentence(document["fulltext"]),
+                    "html": justification_document_html,
+                    "span": f"{j.span_start}:{j.span_end}",
+                }
+            )
+        )
+        justification_file = (
+            docs_dir
+            / f"{document['parent_id']}_{j.span_start}-{j.span_end}.html"
+        )
+        justification_file.write_text(rendered_html)
+
+
 
     def render_element(self, element: Element) -> str:
         html_lines = ["<div>"]

--- a/aida_viz/htmlwriter/core.py
+++ b/aida_viz/htmlwriter/core.py
@@ -35,18 +35,6 @@ class HtmlWriter:
         if self.output_dir.exists() and not self.output_dir.is_dir():
             raise ValueError("argument `output_dir` must be directory.")
 
-        for element in self.elements.values():
-            all_justifications = (
-                element.informative_justifications + element.justified_by
-            )
-            renderable_justifications = [
-                j for j in all_justifications if j.span_start and j.span_end
-            ]
-            for j in renderable_justifications:
-                self.write_justification_context_html(j)
-                if pbar:
-                    pbar.update()
-
         html_file = self.output_dir / output_file_name
 
         html_lines = [
@@ -206,6 +194,8 @@ class HtmlWriter:
                 ]
                 link = f'<a href=docs/{document_id}_{j.span_start}-{j.span_end}.html>"{spanning_tokens}" [{j.span_start}:{j.span_end}]</a>'
                 rendered_justifications.update([link])
+                self.write_justification_context_html(j)
+
         return ", ".join(rendered_justifications)
 
     def anchor_link(self, element_id: URIRef) -> str:

--- a/aida_viz/utils.py
+++ b/aida_viz/utils.py
@@ -1,5 +1,6 @@
-from aida_interchange.rdf_ontologies import interchange_ontology
 from rdflib import Graph, Namespace
+
+from aida_interchange.rdf_ontologies import interchange_ontology
 
 
 def aida_namespace(graph: Graph):


### PR DESCRIPTION
this PR addresses the bug that @danielnapierski found, which resulted in broken links for `Statement` elements.

previously, the visualizer would:
1. collect all of the main AIF elements (Entities, Events, Relations, Clusters)
2. find justifications for each of these elements
3. write "context" html for each of these elements' justifications (in the /docs directory)
4. write visualization html for each element.

the problem with the above is that Statement elements (which descend from Entities, Events, Relations, and Clusters) sometimes have Justifications that are not present in the main AIF elements themselves.

With this fix, every time a Justification is rendered for any reason, a corresponding "context" html file is written to /docs:
1. collect all of the main AIF elements
2. write visualization html for each event
2a. during the visualization, each time a Justification is rendered, write a "context" html file to /docs.